### PR TITLE
Move to NGINX 1.15.4 and Alpine 3.8

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -1,8 +1,8 @@
 # This file is largely copied from https://github.com/nginxinc/docker-nginx/tree/master/mainline/alpine
 
-FROM alpine:3.7
+FROM alpine:3.8
 
-ENV NGINX_VERSION 1.15.3
+ENV NGINX_VERSION 1.15.4
 ENV NGX_DEVEL_KIT_VERSION 0.3.0
 ENV NGX_HTTP_LUA_MODULE_VERSION 0.10.13
 ENV LUA_CJSON_VERSION 2.1.0.6

--- a/mainline/alpine/Makefile
+++ b/mainline/alpine/Makefile
@@ -1,4 +1,4 @@
-NAME := nginx-openresty
+NAME := docker-nginx-openresty
 GITCOMMIT := $(shell git rev-parse --short=10 HEAD 2>/dev/null)
 
 BASE_IMAGE_URL := $(DOCKER_ORG)/$(NAME)


### PR DESCRIPTION
This pull request bumps us to [NGINX 1.15.4](http://nginx.org/en/CHANGES) and Alpine 3.8 (https://alpinelinux.org/posts/Alpine-3.8.0-released.html and https://www.alpinelinux.org/posts/Alpine-3.8.1-released.html). This keeps this repo inline with https://github.com/nginxinc/docker-nginx/commit/866b071f099f96898563f9a003c2dbb03bb90339 and https://github.com/nginxinc/docker-nginx/commit/3c446adddf7b04e877d5c5191b151c794c74bb58.