### PR TITLE
Add lua-resty-core FFI API and lua-resty-lrucache

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -7,10 +7,13 @@ ENV NJS_VERSION 0.2.4
 ENV NGX_DEVEL_KIT_VERSION 0.3.0
 ENV NGX_HTTP_LUA_MODULE_VERSION 0.10.13
 ENV NGX_STREAM_LUA_MODULE_VERSION 0.0.5
+ENV LUA_RESTY_CORE_VERSION 0.1.15
+ENV LUA_RESTY_LRUCACHE_VERSION 0.08
 ENV LUA_CJSON_VERSION 2.1.0.6
 ENV LUAJIT_LIB /usr/lib
 ENV LUAJIT_INC /usr/include/luajit-2.1
 ENV LUA_INCLUDE_DIR /usr/include/luajit-2.1
+ENV LUA_NGINX_LIB_DIR /etc/nginx/conf.d/lua
 
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& CONFIG="\
@@ -83,6 +86,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& curl -fSL https://github.com/openresty/lua-nginx-module/archive/v$NGX_HTTP_LUA_MODULE_VERSION.tar.gz -o lua-nginx-module.tar.gz \
 	&& curl -fSL https://github.com/openresty/stream-lua-nginx-module/archive/v$NGX_STREAM_LUA_MODULE_VERSION.tar.gz -o stream-lua-nginx-module.tar.gz \
 	&& curl -fSL https://github.com/nginx/njs/archive/$NJS_VERSION.tar.gz -o njs.tar.gz \
+	&& curl -fSL https://github.com/openresty/lua-resty-core/archive/v$LUA_RESTY_CORE_VERSION.tar.gz -o lua-resty-core.tar.gz \
+	&& curl -fSL https://github.com/openresty/lua-resty-lrucache/archive/v$LUA_RESTY_LRUCACHE_VERSION.tar.gz -o lua-resty-lrucache.tar.gz \
 	&& curl -fSL https://github.com/openresty/lua-cjson/archive/$LUA_CJSON_VERSION.tar.gz -o lua-cjson.tar.gz \
 	&& curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
 	&& curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
@@ -113,6 +118,10 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& rm njs.tar.gz \
 	&& tar -zxC /usr/src -f lua-cjson.tar.gz \
 	&& rm lua-cjson.tar.gz \
+	&& tar -zxC /usr/src -f lua-resty-core.tar.gz \
+	&& rm lua-resty-core.tar.gz \
+	&& tar -zxC /usr/src -f lua-resty-lrucache.tar.gz \
+	&& rm lua-resty-lrucache.tar.gz \
 	&& cd /usr/src/lua-cjson-$LUA_CJSON_VERSION \
 	&& make -j$(getconf _NPROCESSORS_ONLN) install \
 	&& cd /usr/src/nginx-$NGINX_VERSION \
@@ -139,6 +148,9 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& ln -s ../../usr/lib/nginx/modules /etc/nginx/modules \
 	&& strip /usr/sbin/nginx* \
 	&& strip /usr/lib/nginx/modules/*.so \
+	&& mkdir $LUA_NGINX_LIB_DIR \
+	&& cp -r /usr/src/lua-resty-core-$LUA_RESTY_CORE_VERSION/lib $LUA_NGINX_LIB_DIR \
+	&& cp -r /usr/src/lua-resty-lrucache-$LUA_RESTY_LRUCACHE_VERSION/lib $LUA_NGINX_LIB_DIR \
 	&& rm -rf /usr/src/* \
 	\
 	# Bring in gettext so we can get `envsubst`, then throw

--- a/mainline/alpine/nginx.conf
+++ b/mainline/alpine/nginx.conf
@@ -11,6 +11,11 @@ events {
 
 
 http {
+    lua_package_path '/etc/nginx/conf.d/lua/lib/?.lua;;';
+    init_by_lua_block { 
+        require "resty.core"
+        require "resty.lrucache"
+    }
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 


### PR DESCRIPTION
Add lua-resty-core FFI API and lua-resty-lrucache which is a least recently used cache implementation in Lua using LuaJIT FFI.

This pull request adds the following:
 * https://github.com/openresty/lua-resty-core
 * https://github.com/openresty/lua-resty-lrucache

Both of https://github.com/openresty/lua-nginx-module and https://github.com/openresty/lua-nginx-module have already been included in previous pull requests.