### PR TITLE
Bump to alpine:3.10.1

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # This file is largely copied from https://github.com/nginxinc/docker-nginx/tree/master/mainline/alpine
 
-FROM alpine:3.9.2
+FROM alpine:3.10.1@sha256:6a92cd1fcdc8d8cdec60f33dda4db2cb1fcdcacf3410a8e05b3741f44a9b5998
 
 ENV NGINX_VERSION 1.15.11
 ENV NJS_VERSION 0.3.0


### PR DESCRIPTION
See https://alpinelinux.org/posts/Alpine-3.10.1-released.html. I also began using the digest when referencing the image.
```
~ ❯ docker pull alpine:3.10.1
3.10.1: Pulling from library/alpine
050382585609: Pull complete
Digest: sha256:6a92cd1fcdc8d8cdec60f33dda4db2cb1fcdcacf3410a8e05b3741f44a9b5998
Status: Downloaded newer image for alpine:3.10.1
```